### PR TITLE
Fixes for Accessibility Issues in labels

### DIFF
--- a/_includes/javascript/filters.js
+++ b/_includes/javascript/filters.js
@@ -75,7 +75,7 @@ function renderFilters() {
         filterForm.setAttribute( 'aria-label', 'Search and filter spaces' );
         let controlsContainer = document.createElement( 'div' );
         controlsContainer.classList.add( 'top-controls' );
-        controlsContainer.innerHTML = '<div><label for="search-input" class="visuallyhidden">Search</label><input id="search-input" type="search" placeholder="Search"></div><div class="searchbuttons"><button type="reset" id="search-reset" class="btn" disabled>Reset</button><button type="submit" id="search-submit" class="btn" aria-controls="searchResultsSummary" disabled>Search</button></div></div>';
+        controlsContainer.innerHTML = '<div><label for="search-input" class="visuallyhidden">Search University spaces</label><input id="search-input" type="search" placeholder="Search"></div><div class="searchbuttons"><button type="reset" id="search-reset" class="btn" disabled>Reset<span class="visuallyhidden"> University spaces search and filters</span></button><button type="submit" id="search-submit" class="btn" aria-controls="searchResultsSummary" disabled>Search<span class="visuallyhidden"> University spaces</span></button></div></div>';
         filterForm.appendChild( controlsContainer );
         let panelContainer = document.createElement( 'div' );
         panelContainer.classList.add( 'panel-content' );

--- a/_includes/javascript/spaces.js
+++ b/_includes/javascript/spaces.js
@@ -297,7 +297,7 @@ function sortSpacesListener( event ) {
     /* determine direction from current attribute value */
     let dir = ( sortdir == 'desc' || sortdir == '' ) ? true: false;
 	if ( 'sortalpha' === sortby ) {
-		let sortmsg = dir? 'Sort alphabetically (descending, z-a)': 'Sort alphabetically (ascending, a-z)';
+		let sortmsg = dir? 'Sort alphabetically (descending, z to a)': 'Sort alphabetically (ascending, a to z)';
 		let addbtnclass = dir? 'icon-sort-name-down': 'icon-sort-name-up';
 		let rembtnclass = dir? 'icon-sort-name-up': 'icon-sort-name-down';
 		event.target.setAttribute( 'title', sortmsg );

--- a/_includes/list.html
+++ b/_includes/list.html
@@ -2,7 +2,7 @@
     <p id="searchResultsSummary" aria-live="polite" aria-atomic="true"></p>
     <button type="button" class="geo-button btn icon-my-location" title="Use my location" aria-label="Use my location" disabled></button>
     <button id="sortdistance" data-sortdir="" class="btn sortbutton icon-distance" title="Sort by distance" aria-label="Sort by distance" disabled></button>
-    <button id="sortalpha" data-sortdir="asc" class="btn sortbutton icon-sort-name-down" title="Sort alphabetically (descending, z-a)" aria-label="Sort alphabetically (descending, z-a)"><span class="visuallyhidden">Sort alphabetically (descending, z-a)</span></button>
+    <button id="sortalpha" data-sortdir="asc" class="btn sortbutton icon-sort-name-down" title="Sort alphabetically (descending, z to a)" aria-label="Sort alphabetically (descending, z to a)"><span class="visuallyhidden">Sort alphabetically (descending, z to a)</span></button>
 </div>
 <div id="listcontainer" class="panel-content">
     <div id="listfilters" hidden></div>

--- a/_includes/top-bar.html
+++ b/_includes/top-bar.html
@@ -5,17 +5,17 @@
         <ul>
             <li class="navbutton filter-button" data-view="filters">
                 <button class="icon-search">
-                    <span class="visuallyhidden">Search / Filter</span>
+                    <span class="visuallyhidden">Search or filter University spaces</span>
                 </button>
             </li>
             <li class="navbutton list-button" data-view="list">
                 <button class="icon-list">
-                    <span>List</span>
+                    <span>List<span class="visuallyhidden"> of University spaces</span></span>
                 </button>
             </li>
             <li class="navbutton map-button" data-view="map">
                 <button class="icon-marker">
-                    <span>Map</span>
+                    <span>Map<span class="visuallyhidden"> of University spaces</span></span>
                 </button>
             </li>
             <li class="spacefinder-logo">


### PR DESCRIPTION
* changed the ‘Search’ input label to ‘Search University spaces’.
* changed the ‘Reset’ button’s label to ‘Reset University spaces search and filters’.
* changed the alphabetical sort button label to avoid using hyphens.
* changed the labels in the main navigation to be more descriptive.

closes #20 

